### PR TITLE
Ubuntu compatibility: shebang python3 + remove dot import

### DIFF
--- a/lcheapo/lc2SDS.py
+++ b/lcheapo/lc2SDS.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Read LCHEAPO data into an obspy stream
@@ -12,12 +12,12 @@ import inspect
 from pathlib import Path
 
 from obspy.core import UTCDateTime
-from .sdpchain import ProcessStep
+from sdpchain import ProcessStep
 from progress.bar import IncrementalBar
 
-from .chan_maps import chan_maps
-from .lcread import read as lcread, get_data_timelimits
-from .version import __version__
+from chan_maps import chan_maps
+from lcread import read as lcread, get_data_timelimits
+from version import __version__
 
 
 def lc2SDS():
@@ -237,5 +237,5 @@ def _leap_correct(starttime, ls_times, ls_types):
 # ---------------------------------------------------------------------------
 # Run 'main' if the script is not imported as a module
 # ---------------------------------------------------------------------------
-# if __name__ == '__main__':
-#     main()
+if __name__ == '__main__':
+     lc2SDS()

--- a/lcheapo/lc2ms.py
+++ b/lcheapo/lc2ms.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 create miniSEED file(s) from LCHEAPO file(s)
@@ -10,11 +10,11 @@ import datetime
 import inspect
 from pathlib import Path
 
-from .sdpchain import ProcessStep
+from sdpchain import ProcessStep
 
-from .chan_maps import chan_maps
-from .lcread import read as lcread
-from .version import __version__
+from chan_maps import chan_maps
+from lcread import read as lcread
+from version import __version__
 
 
 def lc2ms():

--- a/lcheapo/lccut.py
+++ b/lcheapo/lccut.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Cut an LCHEAPO file into pieces
@@ -13,8 +13,8 @@ import sys
 from math import floor
 from pathlib import Path
 
-from .sdpchain import ProcessStep
-from .version import __version__
+from sdpchain import ProcessStep
+from version import __version__
 
 BLOCK_SIZE = 512
 MAX_BLOCK_READ = 2048   # max number of blocks to read at once

--- a/lcheapo/lcdump.py
+++ b/lcheapo/lcdump.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Dump record information from an LCHEAPO file
@@ -9,7 +9,7 @@ import sys
 import argparse
 import datetime as dt
 
-from .lcheapo_utils import (LCDiskHeader, LCDirEntry, LCDataBlock)
+from lcheapo_utils import (LCDiskHeader, LCDirEntry, LCDataBlock)
 
 
 # ------------------------------------

--- a/lcheapo/lcfix.py
+++ b/lcheapo/lcfix.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Fix errors and signal time tears in lcheapo files:
@@ -15,9 +15,9 @@ import logging      # for logging information
 from datetime import timedelta
 from pathlib import Path
 
-from .lcheapo_utils import (LCDataBlock, LCDiskHeader, LCDirEntry)
-from .sdpchain import ProcessStep
-from .version import __version__
+from lcheapo_utils import (LCDataBlock, LCDiskHeader, LCDirEntry)
+from sdpchain import ProcessStep
+from version import __version__
 
 # ------------------------------------
 # Global Variable Declarations

--- a/lcheapo/lcheader.py
+++ b/lcheapo/lcheader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Create/modify an LCHEAPO data file header
@@ -11,10 +11,10 @@ import argparse
 from datetime import datetime, timedelta
 from pathlib import Path
 
-from .lcheapo_utils import (LCDiskHeader, LCDirEntry)
-from .version import __version__
+from lcheapo_utils import (LCDiskHeader, LCDirEntry)
+from version import __version__
 
-from .sdpchain.process_steps import ProcessStep
+from sdpchain.process_steps import ProcessStep
 
 # ------------------------------------
 # Global Variable Declarations

--- a/lcheapo/lcheapo_utils.py
+++ b/lcheapo/lcheapo_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Data access for lcheapo files

--- a/lcheapo/lcinfo.py
+++ b/lcheapo/lcinfo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Return basic information about LCHEAPO files
@@ -6,13 +6,13 @@ Return basic information about LCHEAPO files
 By default, returns number of channels, samp_rate and start
 and end of each file
 """
-from .sdpchain import ProcessStep
-from .lcheapo_utils import (LCDataBlock, LCDiskHeader)
+from sdpchain import ProcessStep
+from lcheapo_utils import (LCDataBlock, LCDiskHeader)
 import argparse
 import os
 from datetime import timedelta
 
-from .version import __version__
+from version import __version__
 
 
 def main():

--- a/lcheapo/lcplot.py
+++ b/lcheapo/lcplot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Read LCHEAPO data into an obspy stream
@@ -8,14 +8,15 @@ import re
 
 from obspy.core import UTCDateTime, Stream
 
-from .chan_maps import chan_maps
-from .lcread import read, get_data_timelimits
+from chan_maps import chan_maps
+from lcread import read, get_data_timelimits
 
 
 def main():
     """
     Command-line plotting interface
     """
+
     obs_types = [s for s in chan_maps]
     epilog = "--sfilt returns the first parenthetised subgroup, using \n"
     epilog += "  python's re.search().  Some useful codes are: \n"
@@ -132,5 +133,5 @@ def _normalize_time_arg(a):
 # ---------------------------------------------------------------------------
 # Run 'main' if the script is not imported as a module
 # ---------------------------------------------------------------------------
-# if __name__ == '__main__':
-#     main()
+if __name__ == '__main__':
+    main()

--- a/lcheapo/lcputexamples.py
+++ b/lcheapo/lcputexamples.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Make a directory containing lcheapo examples

--- a/lcheapo/lcread.py
+++ b/lcheapo/lcread.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Read LCHEAPO data into an obspy stream
@@ -13,8 +13,8 @@ import numpy as np
 from obspy.core import UTCDateTime, Stream, Trace
 from obspy import read_inventory
 
-from .lcheapo_utils import (LCDataBlock, LCDiskHeader)
-from .chan_maps import chan_maps
+from lcheapo_utils import (LCDataBlock, LCDiskHeader)
+from chan_maps import chan_maps
 
 
 def read(filename, starttime=None, endtime=None, network='XX', station='SSSSS',

--- a/lcheapo/lctest.py
+++ b/lcheapo/lctest.py
@@ -88,7 +88,7 @@ from obspy.signal import PPSD
 # from crawtools.spectral import SpectralDensity  # PSDs
 from tiskitpy import SpectralDensity  # PSDs
 
-from .lcread import read as lcread
+from lcread import read as lcread
 
 
 def main():

--- a/lcheapo/spectral.py
+++ b/lcheapo/spectral.py
@@ -10,7 +10,7 @@ import numpy as np
 import math as m
 import warnings
 
-from .Peterson_noise_model import PetersonNoiseModel
+from Peterson_noise_model import PetersonNoiseModel
 
 # Set variables
 spect_library = 'scipy'  # 'mlab' or 'scipy': mlab gives weird coherences!


### PR DESCRIPTION
Two mods are done to make lcheapo compatible with Ubuntu.

- replace the python shell shebang (#!) path: python > python3, to make it compatible with legacy Ubuntu versions where python(2) is still running

- remove all "dot import": this does not work on Ubunutu. But does it work on Mac if removed?? it has to be checked first!