### PR TITLE
Correct _get_args description

### DIFF
--- a/lcheapo/lc2SDS.py
+++ b/lcheapo/lc2SDS.py
@@ -155,7 +155,7 @@ def _verify_network_code(s):
 
 def _get_args():
     parser = argparse.ArgumentParser(
-        description=inspect.cleandoc(lc2SDS.__doc__),
+        description=inspect.cleandoc(main.__doc__),
         formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("input_files", nargs='+',
                         help="Input filename(s).  If there are captured "


### PR DESCRIPTION
Solves issue where lc2SDS_py was failing at startup

```sh
lc2SDS_py -h
Traceback (most recent call last):
  File "/home/saurel/miniconda3/envs/obsinfo2/bin/lc2SDS_py", line 7, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/saurel/miniconda3/envs/obsinfo2/lib/python3.13/site-packages/lcheapo/lc2SDS.py", line 39, in main
    args, process_step = _get_args()
                         ~~~~~~~~~^^
  File "/home/saurel/miniconda3/envs/obsinfo2/lib/python3.13/site-packages/lcheapo/lc2SDS.py", line 158, in _get_args
    description=inspect.cleandoc(lc2SDS.__doc__),
                                 ^^^^^^
NameError: name 'lc2SDS' is not defined
```